### PR TITLE
Update README for using CMake FetchContent_Delcare())

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ include(FetchContent)
 FetchContent_Declare(
   mcap_builder
   GIT_REPOSITORY https://github.com/olympus-robotics/mcap_builder.git
+  GIT_TAG main
 )
 FetchContent_MakeAvailable(mcap_builder)
 


### PR DESCRIPTION
The default instructions do not work out of the box because the default branch is called `main` and not `master`.