### PR TITLE
Add option to disable forcing to build MCAP library as shared library

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,7 @@ This has two benefits:
 * it allows to improve the compilation time of your project
 * simplify its usage, by removing the need to specify any macros (see the section above).
 
+The CMake option `MCAP_BUILDER_BUILD_SHARED_LIB` can be used to control the library type:
 
-
+* If enabled (default), the library type will be `SHARED`
+* If disabled, the library will depend on the value of the `BUILD_SHARED_LIBS` variable

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,10 @@
-add_library(mcap SHARED lib.cpp)
+option(MCAP_BUILDER_BUILD_SHARED_LIB "force building MCAP library as shared library" ON)
+
+if (MCAP_BUILDER_BUILD_SHARED_LIB)
+  add_library(mcap SHARED lib.cpp)
+else()
+  add_library(mcap lib.cpp)
+endif()
 
 target_include_directories(mcap PUBLIC
   $<BUILD_INTERFACE:${MCAP_INCLUDE_DIR}>


### PR DESCRIPTION
The CMake option `MCAP_BUILDER_BUILD_SHARED_LIB` can be used to disable forcing to build the MCAP library as shared library.

The default behavior (i.e., if the option is not specified) remains the same as previously.

We ran into issues when running our application which linked against MCAP library while having ROS2 environment sourced. Sourcing ROS2 environment will modify `LD_LIBRARY_PATH` and cause applications that dynamically link against MCAP library to pick up the MCAP library from the ROS2 installation instead of the one that was used during the build.

Linking MCAP library statically is a possible solution to this problem.