### PR TITLE
Update: candidate fix for issues #9, #10, #11, #12, #13, #14, #16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+0.0.x
+-----
+
+* Bug fixes:
+    - resolves 'zstd::libzstd' link target not found … when 'zstdTargets.cmake' exists (issue: #10)
+    - resolves cmake 'FetchContent_MakeAvailable(mcap)' untarring path variance (issue: #11)
+    - resolves absense of some mcap_build test project to confirm a "successful" install (issue: #12)
+    - resolves lack of dependency info propagating to a consuming (e.g. test) project (issue: #13)
+    - resolves lack of pkgconfig fallback when (LZ4|zstd) cmake files not available (issue: #14)
+* Improved code comments
+* Test added
+    - `mcap_builder_check` provides a basic minimal test to check if a "successful" `mcap_builder` install is usable.
+* Updates
+    - Copyrights updated for 2025
+    - Updated MCAP version from "1.4.0" to "1.4.1" (Issue #9)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,12 @@
 # =================================================================================================
-#  Copyright (C) 2023-2024 MCAP_BUILDER Contributors
+#  Copyright (C) 2023-2025 MCAP_BUILDER Contributors
 # =================================================================================================
-
+# FILE: mcap_builder  CMakeLists.txt
 cmake_minimum_required(VERSION 3.22.1)
 
-set(VERSION "1.4.0")
+# Define MCAP project version
+# See: https://github.com/foxglove/mcap#developer-quick-start
+set(VERSION "1.4.1")
 
 project(mcap_builder LANGUAGES CXX VERSION ${VERSION})
 
@@ -18,17 +20,31 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.29")
 else()
   set(DOWNLOAD_EXTRACT_TIMESTAMP_ARG "")
 endif()
+
+# Define MCAP dependency tag and fetch it from GitHub as a tarball
 set(MCAP_TAG "releases/cpp/v${VERSION}")
 FetchContent_Declare(
   mcap
   URL https://github.com/foxglove/mcap/archive/refs/tags/${MCAP_TAG}.tar.gz
   ${DOWNLOAD_EXTRACT_TIMESTAMP_ARG}
+  SOURCE_DIR ${CMAKE_BINARY_DIR}/_deps/mcap-src
 )
-FetchContent_MakeAvailable(mcap)
-set(MCAP_INCLUDE_DIR ${mcap_SOURCE_DIR}/cpp/mcap/include/)
+FetchContent_MakeAvailable(mcap) # Download and populate MCAP dependencies
 
+# Dynamically locate mcap.hpp to handle platform cmake directory variations
+find_path(MCAP_INCLUDE_DIR
+  NAMES mcap/mcap.hpp
+  HINTS ${mcap_SOURCE_DIR}
+  PATH_SUFFIXES cpp/mcap/include mcap-releases-cpp-v${VERSION}/cpp/mcap/include
+  NO_DEFAULT_PATH
+)
+if(NOT MCAP_INCLUDE_DIR)
+  message(FATAL_ERROR "mcap.hpp not found in ${mcap_SOURCE_DIR}")
+endif()
+message(STATUS "MCAP_INCLUDE_DIR set to ${MCAP_INCLUDE_DIR}")
+
+# Delegate to src/CMakeLists.txt to build the mcap library and its dependencies
 add_subdirectory(src)
-
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
@@ -39,11 +55,10 @@ write_basic_package_version_file(
 
 install(TARGETS mcap
     EXPORT mcap-targets
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-    INCLUDES
-    DESTINATION include
+    RUNTIME DESTINATION bin      # Executables go to bin/
+    LIBRARY DESTINATION lib      # Shared libraries go to lib/
+    ARCHIVE DESTINATION lib      # Static libraries go to lib/
+    INCLUDES DESTINATION include # Headers tied to the target go to include/
 )
 install(DIRECTORY ${MCAP_INCLUDE_DIR} DESTINATION include)
 
@@ -52,6 +67,7 @@ configure_package_config_file(
     "${PROJECT_SOURCE_DIR}/cmake/mcap-config.cmake.in"
     "${PROJECT_BINARY_DIR}/mcap-config.cmake"
     INSTALL_DESTINATION lib/cmake/mcap
+    PATH_VARS MCAP_LZ4_FOUND MCAP_ZSTD_FOUND MCAP_LZ4_VIA_PKGCONFIG MCAP_ZSTD_VIA_PKGCONFIG
 )
 
 install(EXPORT mcap-targets DESTINATION lib/cmake/mcap)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ install(TARGETS mcap
     ARCHIVE DESTINATION lib      # Static libraries go to lib/
     INCLUDES DESTINATION include # Headers tied to the target go to include/
 )
-install(DIRECTORY ${MCAP_INCLUDE_DIR} DESTINATION include)
+install(DIRECTORY ${MCAP_INCLUDE_DIR}/mcap/ DESTINATION include/mcap)
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(

--- a/README.md
+++ b/README.md
@@ -2,19 +2,52 @@
 
 This repo provides a wrapper to build and install [MCAP](https://github.com/foxglove/mcap) via CMake.
 
-## Build and Install
+## Build, Install and Test
+
+_Prerequisites_
+
+```bash
+# apt package manager
+sudo apt install lz4 liblz4-dev zstd libzstd-dev
+
+# homebrew package manager
+brew install lz4 zstd
+```
+
+- `pkgconf` may also need to be install on some systems.
+
+
+The current version of the `MCAP` C++ library can be double checked at [foxglove/mcap#developer-quick-start](https://github.com/foxglove/mcap#developer-quick-start) and updated in [CMakeLists.txt ](CMakeLists.txt) `set (VERSION …)` as needed.
 
 To build and install run:
+
 ```bash
-$ cd mcap_builder
-$ mkdir build && cd build
-$ cmake ../ && make install
+git clone git@github.com:olympus-robotics/mcap_builder.git
+cd mcap_builder
+
+mkdir build && cd build
+cmake -S ../ -B . # -Wno-dev reduces CMake-developer-specific warnings clutter
+sudo make install
 ```
 you can change the install folder by setting `CMAKE_INSTALL_PREFIX` (as for any CMake project).
+
+_Test: Check Installation Usability_
+
+``` sh
+cd test/mcap_builder_check
+mkdir build && cd build
+cmake -S ../ -B .
+make
+./mcap_builder_check
+# Successfully included and used mcap library!
+# LZ4: Not available
+# ZSTD: Available
+```
 
 ## Usage
 ### MCAP Is Installed
 If you built and installed as described above, to include MCAP in your library first you need to add it to your CMake:
+
 ```cmake
 find_package(mcap)
 
@@ -25,6 +58,7 @@ and in your code, you can include `reader.hpp` or `writer.hpp`.
 
 ### Build MCAP Locally
 If you do not want to install MCAP, and you want to build it as part of your project you can, in your `CMakeLists.txt` add:
+
 ```cmake
 include(FetchContent)
 FetchContent_Declare(
@@ -49,8 +83,6 @@ target_link_libraries(<target> PUBLIC mcap)
 MCAP is natively a header-only library, but in this wrapper, it is built into a binary library. 
 
 This has two benefits:
+
 * it allows to improve the compilation time of your project
 * simplify its usage, by removing the need to specify any macros (see the section above).
-
-
-

--- a/cmake/mcap-config.cmake.in
+++ b/cmake/mcap-config.cmake.in
@@ -1,7 +1,67 @@
 # =================================================================================================
-#  Copyright (C) 2023-2024 MCAP_BUILDER Contributors
+#  Copyright (C) 2023-2025 MCAP_BUILDER Contributors
 # =================================================================================================
+# FILE: mcap_builder  cmake/mcap-config.cmake.in
 
+### Calls `PACKAGE_INIT` macro to initialize the mcap package configuration.
+### Sets up standard variables that help in determining the package's 
+### installation prefix, related paths and compatibility checks
 @PACKAGE_INIT@
 
-include ( "${CMAKE_CURRENT_LIST_DIR}/mcap-targets.cmake" )
+include(CMakeFindDependencyMacro)
+
+# Handle lz4 dependency
+if(@MCAP_LZ4_FOUND@)
+  if(NOT @MCAP_LZ4_VIA_PKGCONFIG@)
+    find_dependency(lz4 QUIET)
+  endif()
+  if(NOT lz4_FOUND AND @MCAP_LZ4_VIA_PKGCONFIG@)
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+      pkg_check_modules(LZ4 QUIET liblz4)
+      if(LZ4_FOUND)
+        # Create an imported target for lz4 if found via pkg-config
+        if(NOT TARGET LZ4::lz4)
+          add_library(LZ4::lz4 INTERFACE IMPORTED)
+          set_target_properties(LZ4::lz4 PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${LZ4_INCLUDE_DIRS}"
+            INTERFACE_LINK_LIBRARIES "${LZ4_LINK_LIBRARIES}"
+          )
+        endif()
+      else()
+        message(WARNING "lz4 not found via pkg-config in downstream project")
+      endif()
+    else()
+      message(WARNING "lz4 not found and pkg-config unavailable in downstream project")
+    endif()
+  endif()
+endif()
+
+# Handle zstd dependency
+if(@MCAP_ZSTD_FOUND@)
+  if(NOT @MCAP_ZSTD_VIA_PKGCONFIG@)
+    find_dependency(zstd QUIET)
+  endif()
+  if(NOT zstd_FOUND AND @MCAP_ZSTD_VIA_PKGCONFIG@)
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+      pkg_check_modules(ZSTD QUIET libzstd)
+      if(ZSTD_FOUND)
+        # Create an imported target for zstd if found via pkg-config
+        if(NOT TARGET zstd::libzstd)
+          add_library(zstd::libzstd INTERFACE IMPORTED)
+          set_target_properties(zstd::libzstd PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${ZSTD_INCLUDE_DIRS}"
+            INTERFACE_LINK_LIBRARIES "${ZSTD_LINK_LIBRARIES}"
+          )
+        endif()
+      else()
+        message(WARNING "zstd not found via pkg-config in downstream project")
+      endif()
+    else()
+      message(WARNING "zstd not found and pkg-config unavailable in downstream project")
+    endif()
+  endif()
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/mcap-targets.cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,8 @@
+# =================================================================================================
+#  Copyright (C) 2023-2025 MCAP_BUILDER Contributors
+# =================================================================================================
+# FILE: mcap_builder  src/CMakeLists.txt
+
 add_library(mcap lib.cpp)
 
 target_include_directories(mcap PUBLIC
@@ -7,22 +12,98 @@ target_include_directories(mcap PUBLIC
 
 set(DEPENDENCIES "")
 
+# Find lz4
 find_package(lz4 QUIET)
 if (${lz4_FOUND})
   message(STATUS "Found lz4 from ${lz4_DIR}")
-  list(APPEND DEPENDENCIES LZ4::lz4)
+  set(MCAP_LZ4_VIA_PKGCONFIG FALSE PARENT_SCOPE)
+  if (TARGET LZ4::lz4)
+    set(MCAP_LZ4_FOUND TRUE PARENT_SCOPE)
+    list(APPEND DEPENDENCIES LZ4::lz4)
+  else()
+    message(WARNING "LZ4::lz4 not found, disabling lz4")
+    set(MCAP_LZ4_FOUND FALSE PARENT_SCOPE)
+    target_compile_definitions(mcap PUBLIC "MCAP_COMPRESSION_NO_LZ4")
+  endif()
 else()
-  message(WARNING "Dependency LZ4 not found, disabling")
-  target_compile_definitions(mcap PUBLIC "MCAP_COMPRESSION_NO_LZ4")
+  # Fallback to pkg-config for lz4
+  find_package(PkgConfig QUIET)
+  if (PkgConfig_FOUND)
+    pkg_check_modules(LZ4 QUIET liblz4)
+    if (LZ4_FOUND)
+      message(STATUS "Found lz4 via pkg-config")
+      set(MCAP_LZ4_FOUND TRUE PARENT_SCOPE)
+      set(MCAP_LZ4_VIA_PKGCONFIG TRUE PARENT_SCOPE)
+      # Create an imported target for lz4
+      if(NOT TARGET LZ4::lz4)
+        add_library(LZ4::lz4 INTERFACE IMPORTED)
+        set_target_properties(LZ4::lz4 PROPERTIES
+          INTERFACE_INCLUDE_DIRECTORIES "${LZ4_INCLUDE_DIRS}"
+          INTERFACE_LINK_LIBRARIES "${LZ4_LINK_LIBRARIES}"
+        )
+      endif()
+      list(APPEND DEPENDENCIES LZ4::lz4)
+    else()
+      message(WARNING "LZ4 not found via pkg-config, disabling")
+      set(MCAP_LZ4_FOUND FALSE PARENT_SCOPE)
+      set(MCAP_LZ4_VIA_PKGCONFIG FALSE PARENT_SCOPE)
+      target_compile_definitions(mcap PUBLIC "MCAP_COMPRESSION_NO_LZ4")
+    endif()
+  else()
+    message(WARNING "Dependency LZ4 not found, pkg-config not available, disabling")
+    set(MCAP_LZ4_FOUND FALSE PARENT_SCOPE)
+    set(MCAP_LZ4_VIA_PKGCONFIG FALSE PARENT_SCOPE)
+    target_compile_definitions(mcap PUBLIC "MCAP_COMPRESSION_NO_LZ4")
+  endif()
 endif()
 
+# Find zstd
 find_package(zstd QUIET)
 if (${zstd_FOUND})
   message(STATUS "Found zstd from ${zstd_DIR}")
-  list(APPEND DEPENDENCIES zstd::libzstd)
+  set(MCAP_ZSTD_VIA_PKGCONFIG FALSE PARENT_SCOPE)
+  # Check if zstd::libzstd exists, else fallback to zstd::libzstd_static
+  if (TARGET zstd::libzstd)
+    set(MCAP_ZSTD_FOUND TRUE PARENT_SCOPE)
+    list(APPEND DEPENDENCIES zstd::libzstd)
+  elseif (TARGET zstd::libzstd_static)
+    set(MCAP_ZSTD_FOUND TRUE PARENT_SCOPE)
+    list(APPEND DEPENDENCIES zstd::libzstd_static)
+  else()
+    message(WARNING "Neither zstd::libzstd nor zstd::libzstd_static found, disabling zstd")
+    set(MCAP_ZSTD_FOUND FALSE PARENT_SCOPE)
+    target_compile_definitions(mcap PUBLIC "MCAP_COMPRESSION_NO_ZSTD")
+  endif()
 else()
-  message(WARNING "Dependency zstd not found, disabling")
-  target_compile_definitions(mcap PUBLIC "MCAP_COMPRESSION_NO_ZSTD")
+  # Fallback to pkg-config for zstd
+  find_package(PkgConfig QUIET)
+  if (PkgConfig_FOUND)
+    pkg_check_modules(ZSTD QUIET libzstd)
+    if (ZSTD_FOUND)
+      message(STATUS "Found zstd via pkg-config")
+      set(MCAP_ZSTD_FOUND TRUE PARENT_SCOPE)
+      set(MCAP_ZSTD_VIA_PKGCONFIG TRUE PARENT_SCOPE)
+      # Create an imported target for zstd
+      if(NOT TARGET zstd::libzstd)
+        add_library(zstd::libzstd INTERFACE IMPORTED)
+        set_target_properties(zstd::libzstd PROPERTIES
+          INTERFACE_INCLUDE_DIRECTORIES "${ZSTD_INCLUDE_DIRS}"
+          INTERFACE_LINK_LIBRARIES "${ZSTD_LINK_LIBRARIES}"
+        )
+      endif()
+      list(APPEND DEPENDENCIES zstd::libzstd)
+    else()
+      message(WARNING "ZSTD not found via pkg-config, disabling")
+      set(MCAP_ZSTD_FOUND FALSE PARENT_SCOPE)
+      set(MCAP_ZSTD_VIA_PKGCONFIG FALSE PARENT_SCOPE)
+      target_compile_definitions(mcap PUBLIC "MCAP_COMPRESSION_NO_ZSTD")
+    endif()
+  else()
+    message(WARNING "Dependency zstd not found, pkg-config not available, disabling")
+    set(MCAP_ZSTD_FOUND FALSE PARENT_SCOPE)
+    set(MCAP_ZSTD_VIA_PKGCONFIG FALSE PARENT_SCOPE)
+    target_compile_definitions(mcap PUBLIC "MCAP_COMPRESSION_NO_ZSTD")
+  endif()
 endif()
 
 target_link_libraries(mcap PUBLIC ${DEPENDENCIES})

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -1,6 +1,7 @@
 //=================================================================================================
-// Copyright (C) 2023-2024 MCAP_BUILDER Contributors
+// Copyright (C) 2023-2025 MCAP_BUILDER Contributors
 //=================================================================================================
+// FILE: mcap_builder  src/lib.cpp
 
 #define MCAP_IMPLEMENTATION
 #include <mcap/mcap.hpp>

--- a/test/mcap_builder_check/CMakeLists.txt
+++ b/test/mcap_builder_check/CMakeLists.txt
@@ -1,0 +1,18 @@
+# =================================================================================================
+#  Copyright (C) 2023-2025 MCAP_BUILDER Contributors
+# =================================================================================================
+# FILE: test/mcap_builder_check  CMakeLists.txt
+
+cmake_minimum_required(VERSION 3.22.1)
+project(mcap_builder_check LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+
+# Find the installed mcap package
+find_package(mcap REQUIRED)
+
+# Create an executable
+add_executable(mcap_builder_check main.cpp)
+
+# Link against the mcap library
+target_link_libraries(mcap_builder_check PUBLIC mcap)

--- a/test/mcap_builder_check/README.md
+++ b/test/mcap_builder_check/README.md
@@ -1,0 +1,16 @@
+# Readme: `mcap_builder_check`
+
+```sh
+cd test/mcap_builder_check
+
+mkdir build
+cd build
+cmake -S ../ -B .
+
+make VERBOSE=1
+./mcap_builder_check
+# Successfully included and used mcap library!
+# LZ4: Not available
+# ZSTD: Available
+```
+

--- a/test/mcap_builder_check/main.cpp
+++ b/test/mcap_builder_check/main.cpp
@@ -1,0 +1,23 @@
+//=================================================================================================
+// Copyright (C) 2023-2025 MCAP_BUILDER Contributors
+//=================================================================================================
+// FILE: mcap_builder_check  main.cpp
+
+#include <mcap/mcap.hpp>
+#include <iostream>
+
+int main() {
+    mcap::McapWriter writer;
+    std::cout << "Successfully included and used mcap library!\n";
+    #ifdef MCAP_COMPRESSION_NO_LZ4
+    std::cout << "LZ4: Not available\n";
+    #else
+    std::cout << "LZ4: Available\n";
+    #endif
+    #ifdef MCAP_COMPRESSION_NO_ZSTD
+    std::cout << "ZSTD: Not available\n";
+    #else
+    std::cout << "ZSTD: Available\n";
+    #endif
+    return 0;
+}


### PR DESCRIPTION
The process of building, installing and subsequently using MCAP, as provided via `mcap_builder`, uncovered the issues listed below:

- [#9 A patch version update from 1.4.0 to 1.4.1 is available](https://github.com/olympus-robotics/mcap_builder/issues/9)
- [#10 'zstd::libzstd' link target not found … when 'zstdTargets.cmake' exists](https://github.com/olympus-robotics/mcap_builder/issues/10)
- [#11 cmake 'FetchContent_MakeAvailable(mcap)' untarring path variance](https://github.com/olympus-robotics/mcap_builder/issues/11)
- [#12 Needs some mcap_build test project to confirm "successful" install](https://github.com/olympus-robotics/mcap_builder/issues/12)
- [#13 Dependency info (LZ4|zstd) not propagating to consuming project](https://github.com/olympus-robotics/mcap_builder/issues/13)
- [#14 provide (LZ4|zstd) pkgconf fallback when cmake files are not available](https://github.com/olympus-robotics/mcap_builder/issues/14)

The issues were discovered on the platform set: macOS (brew arm64), Raspberry Pi OS (2024-11-19, Debian 12, arm64) and Ubuntu 22.04 (x86_64).

A comprehensive solution for this issue set was implemented and tested on the same platform set. This pull request provides the tested candidate fixes for issues #9, #10, #11, #12, #13, and #14.